### PR TITLE
fix: use contexts instead of extras

### DIFF
--- a/sentry/handler.go
+++ b/sentry/handler.go
@@ -77,15 +77,10 @@ func New(opts Options) httputil.Middleware {
 			}
 			hub.WithScope(func(scope *sentrysdk.Scope) {
 				msg := p.Title
+				pc := newProblemContext(p)
+				scope.SetContext("problemDetails", pc)
 				if p.Detail != "" {
-					scope.SetExtra("problem.detail", p.Detail)
 					msg = p.Detail
-				}
-				if p.Status != 0 {
-					scope.SetExtra("problem.status", p.Status)
-				}
-				if p.Instance != "" {
-					scope.SetExtra("problem.instance", p.Instance)
 				}
 				_ = hub.CaptureMessage(msg)
 				if opts.WaitForDelivery {
@@ -93,5 +88,21 @@ func New(opts Options) httputil.Middleware {
 				}
 			})
 		})
+	}
+}
+
+type problemContext struct {
+	Detail   string `json:"detail,omitempty"`
+	Status   int    `json:"status,omitempty"`
+	Instance string `json:"instance,omitempty"`
+	Type     string `json:"problemType,omitempty"`
+}
+
+func newProblemContext(p *problems.DefaultProblem) *problemContext {
+	return &problemContext{
+		Detail:   p.Detail,
+		Status:   p.Status,
+		Instance: p.Instance,
+		Type:     p.Type,
 	}
 }

--- a/sentry/handler_test.go
+++ b/sentry/handler_test.go
@@ -32,8 +32,13 @@ func Test_ok(t *testing.T) {
 				{
 					Level:   sentrysdk.LevelInfo,
 					Message: http.StatusText(http.StatusInternalServerError),
-					Extra: map[string]interface{}{
-						"problem.status": http.StatusInternalServerError,
+					Extra:   map[string]interface{}{},
+					Contexts: map[string]interface {
+					}{
+						"problemDetails": &problemContext{
+							Type:   "about:blank",
+							Status: http.StatusInternalServerError,
+						},
 					},
 				},
 			},
@@ -46,9 +51,14 @@ func Test_ok(t *testing.T) {
 				{
 					Level:   sentrysdk.LevelInfo,
 					Message: "some details",
-					Extra: map[string]interface{}{
-						"problem.status": http.StatusInternalServerError,
-						"problem.detail": "some details",
+					Extra:   map[string]interface{}{},
+					Contexts: map[string]interface {
+					}{
+						"problemDetails": &problemContext{
+							Type:   "about:blank",
+							Status: http.StatusInternalServerError,
+							Detail: "some details",
+						},
 					},
 				},
 			},
@@ -61,9 +71,14 @@ func Test_ok(t *testing.T) {
 				{
 					Level:   sentrysdk.LevelInfo,
 					Message: http.StatusText(http.StatusInternalServerError),
-					Extra: map[string]interface{}{
-						"problem.status":   http.StatusInternalServerError,
-						"problem.instance": "http://instance.example/",
+					Extra:   map[string]interface{}{},
+					Contexts: map[string]interface {
+					}{
+						"problemDetails": &problemContext{
+							Type:     "about:blank",
+							Status:   http.StatusInternalServerError,
+							Instance: "http://instance.example/",
+						},
 					},
 				},
 			},
@@ -82,8 +97,13 @@ func Test_ok(t *testing.T) {
 				{
 					Level:   sentrysdk.LevelInfo,
 					Message: http.StatusText(http.StatusBadRequest),
-					Extra: map[string]interface{}{
-						"problem.status": http.StatusBadRequest,
+					Extra:   map[string]interface{}{},
+					Contexts: map[string]interface {
+					}{
+						"problemDetails": &problemContext{
+							Type:   "about:blank",
+							Status: http.StatusBadRequest,
+						},
 					},
 				},
 			},
@@ -165,10 +185,13 @@ func withSentryHub() httputil.Middleware {
 var sentryEventCmpOptions = cmp.Options{
 	cmpopts.IgnoreFields(
 		sentry.Event{},
-		"Contexts", "EventID", "Platform", "Release", "Sdk", "ServerName", "Tags", "Timestamp",
+		"EventID", "Platform", "Release", "Sdk", "ServerName", "Tags", "Timestamp",
 	),
 	cmpopts.IgnoreFields(
 		sentry.Request{},
 		"Env",
 	),
+	cmpopts.IgnoreMapEntries(func(key string, value interface{}) bool {
+		return key != "problemDetails"
+	}),
 }


### PR DESCRIPTION
Additional Data (extras) is deprecated.
refs. https://docs.sentry.io/platforms/go/enriching-events/context/#additional-data